### PR TITLE
Fix historical_download.R to avoid loosing datasets from stations wit…

### DIFF
--- a/R/current_download.R
+++ b/R/current_download.R
@@ -21,7 +21,7 @@ current_download <- function(id = "ESCAT080000000", save_excel = TRUE) {
 
   data_final <- list()
   for (ii in id) {
-    xml.lonlat <- paste0("http://meteoclimatic.com/feed/rss/",ii) # lon lat
+    xml.lonlat <- paste0("http://meteoclimatic.net/feed/rss/",ii) # lon lat
     lonlat <- xmlParse(rawToChar(GET(xml.lonlat)$content))
     lonlat.l <- t(xmlToList(lonlat, simplify = TRUE))
 

--- a/R/historical_download.R
+++ b/R/historical_download.R
@@ -104,7 +104,7 @@ historical_download <- function(id = "ESIBA", dates = c("2021-05-16","2021-07-15
 
     tab_data <- bind_rows(tab_data)
     ## COORDENADES BASE ACTUAL
-    xml.lonlat <- paste0("http://meteoclimatic.com/feed/rss/",id) # lon lat
+    xml.lonlat <- paste0("http://meteoclimatic.net/feed/rss/",id) # lon lat
     lonlat <- xmlParse(rawToChar(GET(xml.lonlat)$content))
     lonlat.l <- t(xmlToList(lonlat, simplify = TRUE))
 

--- a/R/historical_download.R
+++ b/R/historical_download.R
@@ -109,10 +109,6 @@ historical_download <- function(id = "ESIBA", dates = c("2021-05-16","2021-07-15
     lonlat.l <- t(xmlToList(lonlat, simplify = TRUE))
 
     coords <- lonlat.l[11:length(lonlat.l)-1]
-    coords <- lapply(coords, function(x) { xpre <- x
-    xpre$title <- iconv(x$title, from = "UTF-8", to = "ISO-8859-15")
-    x <- xpre
-    })
     coords<- tibble(coord = coords)
 
     coords <-coords %>%


### PR DESCRIPTION
…h special characters

Fix historical_download.R to avoid loosing datasets from stations with special characters. When the char conversion is in place, stations that hold some accent (Gràcia, etc) don't get stored on disk. Removing these lines related to charset conversion makes all stations to get stored on disk as expected. etc.  Thanks for the awesome work you've done, lemuscasanovas 

(també em vaig formar a Ciències Experimentals de Palau Reial - UB, doctorat en Ecologia en el meu cas :-) .